### PR TITLE
Better stroke preview bounds

### DIFF
--- a/crates/lapiz_brush/shaders/compose_stroke_preview.wesl
+++ b/crates/lapiz_brush/shaders/compose_stroke_preview.wesl
@@ -32,14 +32,24 @@ fn sample_result(pixel: vec2f) -> vec4f {
 @compute
 @workgroup_size(16, 16, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3u) {
-    let output_size = textureDimensions(output);
-    if any(global_id.xy >= output_size) {
+    if any(global_id.xy >= textureDimensions(output)) {
         return;
     }
 
+    let output_size = vec2f(textureDimensions(output));
     let bounds_min = vec2f(result_bounds.xy);
     let bounds_size = vec2f(result_bounds.zw - result_bounds.xy);
-    let uv = (vec2f(global_id.xy) + 0.5) / vec2f(output_size);
-    let result_pixel = bounds_min + uv * bounds_size - 0.5;
+
+    if any(bounds_size == vec2f(0.0)) {
+        return;
+    }
+
+    let scale = min(output_size.x / bounds_size.x, output_size.y / bounds_size.y);
+    let scaled_bounds_size = bounds_size * scale;
+    let scaled_bounds_min = (output_size - scaled_bounds_size) * 0.5;
+
+    let pixel = vec2f(global_id.xy) + 0.5;
+    let result_pixel = bounds_min + (pixel - scaled_bounds_min) / scale - 0.5;
+
     textureStore(output, global_id.xy, sample_result(result_pixel));
 }

--- a/crates/lapiz_brush/src/render/stroke_preview.rs
+++ b/crates/lapiz_brush/src/render/stroke_preview.rs
@@ -9,6 +9,7 @@ use iced_runtime::Task;
 use image::{ImageFormat, RgbaImage};
 use lapiz_assets::asset::AssetHandle;
 use lapiz_image::{
+    layer_bounds::LayerBoundsPipeline,
     texel::TexelType,
     tile::{DynamicLayerStorage, GpuLayerInfo, GpuTileInfo, GpuTileStorage, LayerBinding},
 };
@@ -30,7 +31,7 @@ use lapiz_utils::log_err::LogErr;
 use tracing::info;
 use wesl::include_wesl;
 use wgpu::{
-    BindGroupDescriptor, BindGroupLayout, BindGroupLayoutDescriptor, BufferUsages,
+    BindGroupDescriptor, BindGroupLayout, BindGroupLayoutDescriptor, Buffer, BufferUsages,
     ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, Device, Extent3d,
     PipelineLayoutDescriptor, Queue, ShaderModuleDescriptor, ShaderSource, ShaderStages,
     StorageTextureAccess, Texture, TextureDescriptor, TextureDimension, TextureFormat,
@@ -277,27 +278,18 @@ fn map_result_texture(
         view_formats: &[],
     });
 
-    let result_binding = result.binding();
-    let tile_bounds = result.compute_tile_bounds();
-    let Some(result_binding) = result_binding else {
+    let Some(result_binding) = result.binding() else {
         return output_texture;
     };
-    if tile_bounds.is_empty() {
-        return output_texture;
-    }
-    let pixel_bounds = GpuTileStorage::tile_rect_to_pixel(tile_bounds);
-
-    let mut result_bounds = DynamicBuffer::new(
-        Some("stroke preview result bounds".into()),
-        BufferUsages::STORAGE,
+    let mut ec = device.create_command_encoder(&Default::default());
+    let result_bounds = LayerBoundsPipeline::new(&device, TexelType::RGBA8, false).dispatch(
+        &device,
+        &queue,
+        &mut ec,
+        &result_binding,
+        None,
     );
-    result_bounds.push(&IVec4::new(
-        pixel_bounds.min.x,
-        pixel_bounds.min.y,
-        pixel_bounds.max.x,
-        pixel_bounds.max.y,
-    ));
-    result_bounds.write_buffer(&device, &queue);
+    queue.submit([ec.finish()]);
 
     ComposeStrokePreviewPipeline::new(&device).dispatch(
         &device,
@@ -362,7 +354,7 @@ impl ComposeStrokePreviewPipeline {
         device: &Device,
         queue: &Queue,
         result: &LayerBinding,
-        result_bounds: &DynamicBuffer<IVec4>,
+        result_bounds: &Buffer,
         output: &Texture,
     ) {
         let output_view = output.create_view(&TextureViewDescriptor::default());
@@ -372,7 +364,7 @@ impl ComposeStrokePreviewPipeline {
             entries: BindGroupEntries::sequential((
                 &result.texture,
                 result.tile_info_buffer.as_entire_binding(),
-                result_bounds.binding().unwrap(),
+                result_bounds.as_entire_binding(),
                 &output_view,
             ))
             .as_ref(),

--- a/crates/lapiz_brush/src/render/stroke_preview.rs
+++ b/crates/lapiz_brush/src/render/stroke_preview.rs
@@ -11,7 +11,7 @@ use lapiz_assets::asset::AssetHandle;
 use lapiz_image::{
     layer_bounds::LayerBoundsPipeline,
     texel::TexelType,
-    tile::{DynamicLayerStorage, GpuLayerInfo, GpuTileInfo, GpuTileStorage, LayerBinding},
+    tile::{DynamicLayerStorage, GpuLayerInfo, GpuTileInfo, LayerBinding},
 };
 use lapiz_render::{
     bind_group_entries::BindGroupEntries,

--- a/crates/lapiz_image/src/layer_bounds.rs
+++ b/crates/lapiz_image/src/layer_bounds.rs
@@ -153,24 +153,3 @@ impl LayerBoundsPipeline {
         result_buffer
     }
 }
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn layer_bounds_wesl_compiles() {
-        use crate::texel::TexelType;
-        use lapiz_render::wesl_jit;
-        for format in [TexelType::RGBA8, TexelType::A8] {
-            for with_selection in [true, false] {
-                wesl_jit::compile_wesl_with_config(
-                    include_str!("layer_bounds.wesl").into(),
-                    &[&crate::image::PACKAGE],
-                    |compiler| {
-                        compiler.set_feature(format.shader_def(), true);
-                        compiler.set_feature("WITH_SELECTION", with_selection);
-                    },
-                )
-                .unwrap();
-            }
-        }
-    }
-}


### PR DESCRIPTION
No longer stretches the preview image, but fit it tightly.